### PR TITLE
Fix npm and Cloud SDK product names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
-# gcloud SDK package for NPM
-This package is an [NPM][npm] wrapper around the [gcloud SDK][gcloud-sdk] installer for [Google Cloud Platform][gcp]. It supports OSX, Windows, and Linux.
+# Google Cloud SDK package for npm
+This package is an [npm][npm] wrapper around the [Cloud SDK][cloud-sdk] installer for [Google Cloud Platform][gcp]. It supports OSX, Windows, and Linux.
 
-If the gcloud SDK is not present on your machine, this package will install it. Otherwise, it will update the existing installation using `gcloud components update`.
+If the Cloud SDK is not present on your machine, this package will install it. Otherwise, it will update the existing installation using `gcloud components update`.
 
 ## Use
-```
+
+You can install the Cloud SDK for use globally:
+```sh
 npm install -g @google-cloud/cloud-sdk
+```
+
+Or use it as a dev dependency:
+```sh
+npm install --save-dev @google-cloud/cloud-sdk
 ```
 
 ## Dependencies
@@ -16,7 +23,7 @@ On Linux and OSX, this package requires either `bash`, `fish`, or `zsh`.
 ## Caveats
 This package has several caveats:
  - This package adds a PATH entry pointing to the gcloud binary, which must be manually removed
- - On Windows, this package installs a specific version of the gcloud SDK if no existing installation is detected. Otherwise, it installs (or updates to) the newest available version.
+ - On Windows, this package installs a specific version of the Cloud SDK if no existing installation is detected. Otherwise, it installs (or updates to) the newest available version.
  - Multiple installations: this package can only be installed in one location at a time. If the first installation is removed, this package must be reinstalled to restore gcloud access.
  - Shell detection: on OSX and Linux, this package relies on the `SHELL` environment variable. If this is not set correctly, `gcloud` may not be added to the user's path.
  - This package runs a `postinstall` script. If `postinstall` scripts are not enabled (e.g. due to `npm install --ignore-scripts`), then this package will not install correctly.
@@ -35,5 +42,5 @@ design decisions, and/or Google's commitment to it may change rapidly and/or wit
 Furthermore, this is not an official Google product - experimental or otherwise.
 
 [npm]: https://npmjs.org
-[gcloud-sdk]: https://cloud.google.com/sdk/
+[cloud-sdk]: https://cloud.google.com/sdk/
 [gcp]: https://cloud.google.com/nodejs

--- a/helpers-logging.js
+++ b/helpers-logging.js
@@ -21,7 +21,7 @@ const childProcess = require('child_process');
 // Get constants
 const NPM_LOGLEVEL = childProcess.execSync(`npm config get loglevel`).toString().trim();
 
-// Helper function to get stdio config (for childProcess.execSync) as a function of NPM log level
+// Helper function to get stdio config (for childProcess.execSync) as a function of npm log level
 // @returns a dictionary compatible with childProcess.execSync's "stdio" parameter
 function getStdioConfig () {
   let stdioConfig = { stdio: ['inherit', 'inherit', 'inherit'] };
@@ -50,7 +50,7 @@ function getLoggerInstance () {
     logger.setLevel(LOGGER_LOGLEVEL);
   } else {
     logger.setLevel('warn');
-    logger.warn(`NPM log level '${NPM_LOGLEVEL}' is unsupported; using default of 'warn'`);
+    logger.warn(`npm log level '${NPM_LOGLEVEL}' is unsupported; using default of 'warn'`);
   }
   return logger;
 }


### PR DESCRIPTION
Fixing up product names.  `npm` is all lower case.  `gcloud` is technically called the Cloud SDK :) 